### PR TITLE
Patches odd t.trim is not a function error

### DIFF
--- a/src/common/string-ratchet.ts
+++ b/src/common/string-ratchet.ts
@@ -127,7 +127,12 @@ export class StringRatchet {
   }
 
   public static trimToEmpty(input: string): string {
-    const t: string = input || '';
+    // AG:12.16.2020 - Swapping out the OR for a null coalesce operator
+    // Neon was throwing an error: t.trim is not a function so it is possible
+    // that if the input was null it was trying to trim it. This will no
+    // longer happen.
+    // WAS: const t: string = input || '';
+    const t: string = input ?? '';
     return t.trim();
   }
 


### PR DESCRIPTION
- the error "r.trim is not a function" was bubbling up in Neon through Epsilon when pulling content.
- swapping the OR out for the null coalesce operator to make sure it defaults to the empty string if null or undefined.