### PR TITLE
Set bcc to inRts.bccAddresses when it's set. Instead of always autoBcc

### DIFF
--- a/src/aws/ses/mailer.ts
+++ b/src/aws/ses/mailer.ts
@@ -187,10 +187,7 @@ export class Mailer {
       Logger.info('After cleaning email lists, no destination addresses left - not sending email');
     } else {
       const toLine: string = 'To: ' + rts.destinationAddresses.join(', ') + '\n';
-      const bccLine: string =
-        !!this.config.autoBccAddresses && this.config.autoBccAddresses.length > 0
-          ? 'Bcc: ' + this.config.autoBccAddresses.join(', ') + '\n'
-          : '';
+      const bccLine: string = !!rts.bccAddresses && rts.bccAddresses.length > 0 ? 'Bcc: ' + rts.bccAddresses.join(', ') + '\n' : '';
 
       try {
         const from: string = rts.fromAddress || this.config.defaultSendingAddress;


### PR DESCRIPTION
We can reuse that for bccLine. Now emails will go to inRts.bccAddresses when it's set (instead of always going to autoBcc).