### PR TITLE
fix: ensure null is replaced by default value

### DIFF
--- a/src/common/number-ratchet.spec.ts
+++ b/src/common/number-ratchet.spec.ts
@@ -46,6 +46,11 @@ describe('#safeToNumber', function () {
     const result: number = NumberRatchet.safeNumber({ test: '' }, 42);
     expect(result).toEqual(42);
   });
+
+  it('should return the default for null', function () {
+    const result: number = NumberRatchet.safeNumber(null, 42);
+    expect(result).toEqual(42);
+  });
 });
 
 describe('#parseCSV', function () {

--- a/src/common/number-ratchet.ts
+++ b/src/common/number-ratchet.ts
@@ -46,25 +46,21 @@ export class NumberRatchet {
   // If its a number, leave it alone, if its a string, parse it, anything else, use the default
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public static safeNumber(input: any, ifNotNumber: number = null): number {
-    let rval: number = null;
-    if (input != null) {
+    let rval: number = ifNotNumber;
+    if (input !== null) {
       const type: string = typeof input;
       if (type == 'number') {
         rval = input;
       } else if (type == 'string') {
-        if (input.trim().length === 0) {
-          rval = ifNotNumber;
-        } else {
+        if (input.trim().length > 0) {
           rval = Number.parseFloat(input);
         }
       } else {
         Logger.warn('Value is of type %s, returning default', type);
-        rval = ifNotNumber;
       }
 
       if (isNaN(rval)) {
         Logger.debug('Parsed string to NaN - using NaN value from param');
-        rval = ifNotNumber;
       }
     }
 


### PR DESCRIPTION
This would ensure that if a `null` value is passed to `safeNumber` and a default value has been provided, the default value will be returned.