### PR TITLE
Fix to safeNumber to return null if input is undefined by default

### DIFF
--- a/src/common/number-ratchet.spec.ts
+++ b/src/common/number-ratchet.spec.ts
@@ -61,11 +61,14 @@ describe('#safeToNumber', function () {
     expect(result2).toEqual(undefined);
   });
 
-  it('should return the passed value for null/undefined if not set', function () {
+  it('should return null for an undefined input by default', function () {
+    const result: number | null = NumberRatchet.safeNumber(undefined, 0);
+    expect(result).toEqual(null);
+  });
+
+  it('should return null for a null input by default', function () {
     const result: number = NumberRatchet.safeNumber(null, 42);
     expect(result).toEqual(null);
-    const result2: number = NumberRatchet.safeNumber(undefined, 46);
-    expect(result2).toEqual(undefined);
   });
 });
 

--- a/src/common/number-ratchet.ts
+++ b/src/common/number-ratchet.ts
@@ -72,7 +72,13 @@ export class NumberRatchet {
         rval = ifNotNumber;
       }
     } else {
-      rval = useDefaultForNullAndUndefined ? ifNotNumber : input;
+      if (useDefaultForNullAndUndefined === undefined) {
+        // Use backward-compatible behavior.
+        // Return null if input is either undefined or null.
+        rval = null;
+      } else {
+        rval = useDefaultForNullAndUndefined ? ifNotNumber : input;
+      }
     }
 
     return rval;


### PR DESCRIPTION
Previous versions of `Ratchet` had `NumberRatchet.safeNumber` returning `null` if the input was `undefined`. This modifies the logic to continue doing that (by default) but inherit the new behavior if the recently-added parameter (`useDefaultForNullAndUndefined`) is specified.

Also adds / modifies tests to help avoid regression.