### PR TITLE
DynamoDB client fixes for AWS SDK v3

### DIFF
--- a/src/aws/cache/dynamo-db-storage-provider.ts
+++ b/src/aws/cache/dynamo-db-storage-provider.ts
@@ -7,15 +7,12 @@ import { SimpleCacheObjectWrapper } from './simple-cache-object-wrapper';
 import { SimpleCacheStorageProvider } from './simple-cache-storage-provider';
 import { RequireRatchet } from '../../common/require-ratchet';
 import { DynamoRatchet } from '../dynamodb/dynamo-ratchet';
-import { PutItemCommandOutput, ScanCommandInput } from '@aws-sdk/client-dynamodb';
+import { PutCommandOutput, ScanCommandInput } from '@aws-sdk/lib-dynamodb';
 import { DocQueryCommandInput } from '../model/dynamo/doc-query-command-input';
 
 export class DynamoDbStorageProvider implements SimpleCacheStorageProvider {
   // If hash key is provided, then the cache key is the range, otherwise the cache key is the hash
-  constructor(
-    private dynamo: DynamoRatchet,
-    private opts: DynamoDbSimpleCacheOptions,
-  ) {
+  constructor(private dynamo: DynamoRatchet, private opts: DynamoDbSimpleCacheOptions) {
     RequireRatchet.notNullOrUndefined(this.dynamo, 'dynamo');
     RequireRatchet.notNullOrUndefined(this.opts, 'opts');
     RequireRatchet.notNullOrUndefined(this.opts.tableName, 'opts.tableName');
@@ -86,7 +83,7 @@ export class DynamoDbStorageProvider implements SimpleCacheStorageProvider {
     if (this.opts.dynamoExpiresColumnName && value.expiresEpochMS) {
       toSave[this.opts.dynamoExpiresColumnName] = Math.floor(value.expiresEpochMS / 1000);
     }
-    const wrote: PutItemCommandOutput = await this.dynamo.simplePut(this.opts.tableName, toSave);
+    const wrote: PutCommandOutput = await this.dynamo.simplePut(this.opts.tableName, toSave);
     return !!wrote;
   }
 

--- a/src/aws/dynamodb/dynamo-ratchet-like.ts
+++ b/src/aws/dynamodb/dynamo-ratchet-like.ts
@@ -1,6 +1,6 @@
 import { DynamoCountResult } from '../model/dynamo-count-result';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { DeleteItemCommandOutput, PutItemOutput } from '@aws-sdk/client-dynamodb';
+import { DeleteCommandOutput, PutCommandOutput } from '@aws-sdk/lib-dynamodb';
 import { DocQueryCommandInput } from '../model/dynamo/doc-query-command-input';
 import { DocScanCommandInput } from '../model/dynamo/doc-scan-command-input';
 
@@ -17,7 +17,7 @@ export interface DynamoRatchetLike {
     qry: DocQueryCommandInput,
     proc: (val: T) => Promise<void>,
     delayMS?: number,
-    softLimit?: number,
+    softLimit?: number
   ): Promise<number>;
 
   fullyExecuteScanCount(scan: DocScanCommandInput, delayMS?: number): Promise<DynamoCountResult>;
@@ -26,7 +26,7 @@ export interface DynamoRatchetLike {
     scan: DocScanCommandInput,
     proc: (val: T) => Promise<void>,
     delayMS?: number,
-    softLimit?: number,
+    softLimit?: number
   ): Promise<number>;
 
   writeAllInBatches<T>(tableName: string, elements: T[], batchSize: number): Promise<number>;
@@ -34,7 +34,7 @@ export interface DynamoRatchetLike {
   fetchAllInBatches<T>(tableName: string, inKeys: any[], batchSize: number): Promise<T[]>;
   deleteAllInBatches(tableName: string, keys: any[], batchSize: number): Promise<number>;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  simplePut(tableName: string, value: any, autoRetryCount?: number): Promise<PutItemOutput>;
+  simplePut(tableName: string, value: any, autoRetryCount?: number): Promise<PutCommandOutput>;
   simplePutOnlyIfFieldIsNullOrUndefined(tableName: string, value: any, fieldName: string): Promise<boolean>;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   // This works like simplePut, but if a collision is detected it adjusts the object and tries writing again
@@ -45,7 +45,7 @@ export interface DynamoRatchetLike {
     keyNames: string[],
     adjustFunction: (val: T) => T,
     maxAdjusts?: number,
-    autoRetryCount?: number,
+    autoRetryCount?: number
   ): Promise<T>;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   simpleGet<T>(tableName: string, keys: any, autoRetryCount?: number): Promise<T>;
@@ -55,10 +55,10 @@ export interface DynamoRatchetLike {
     keys: any,
     counterAttributeName: string,
     deleteOnZero: boolean,
-    autoRetryCount?: number,
+    autoRetryCount?: number
   ): Promise<T>;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  simpleDelete(tableName: string, keys: any): Promise<DeleteItemCommandOutput>;
+  simpleDelete(tableName: string, keys: any): Promise<DeleteCommandOutput>;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   atomicCounter(tableName: string, keys: any, counterFieldName: string, increment?: number): Promise<number>;
 }

--- a/src/aws/dynamodb/dynamo-ratchet.spec.ts
+++ b/src/aws/dynamodb/dynamo-ratchet.spec.ts
@@ -2,7 +2,7 @@ import { DynamoRatchet } from './dynamo-ratchet';
 import { Logger } from '../../common/logger';
 import { LoggerLevelName } from '../../common/logger-support/logger-level-name';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { PutItemCommandOutput, ScanCommandInput } from '@aws-sdk/client-dynamodb';
+import { PutCommandOutput, ScanCommandInput } from '@aws-sdk/lib-dynamodb';
 import { DocQueryCommandInput } from '../model/dynamo/doc-query-command-input';
 
 import { mockClient } from 'aws-sdk-client-mock';
@@ -145,7 +145,7 @@ describe('#dynamoRatchet', function () {
     };
 
     for (let i = 0; i < 5; i++) {
-      const rval: PutItemCommandOutput = await dr.simplePutWithCollisionAvoidance(
+      const rval: PutCommandOutput = await dr.simplePutWithCollisionAvoidance(
         'cwtest',
         val,
         ['k1', 'k2'],
@@ -154,7 +154,7 @@ describe('#dynamoRatchet', function () {
           return v;
         },
         null,
-        3,
+        3
       );
       Logger.info('output was : %j', rval);
     }

--- a/src/aws/expiring-code/dynamo-expiring-code-provider.ts
+++ b/src/aws/expiring-code/dynamo-expiring-code-provider.ts
@@ -2,13 +2,10 @@ import { ExpiringCodeProvider } from './expiring-code-provider';
 import { DynamoRatchet } from '../dynamodb/dynamo-ratchet';
 import { ExpiringCode } from './expiring-code';
 import { DynamoTableRatchet } from '../dynamodb/dynamo-table-ratchet';
-import { PutItemOutput } from '@aws-sdk/client-dynamodb';
+import { PutCommandOutput } from '@aws-sdk/lib-dynamodb';
 
 export class DynamoExpiringCodeProvider implements ExpiringCodeProvider {
-  constructor(
-    private tableName: string,
-    private dynamoRatchet: DynamoRatchet,
-  ) {}
+  constructor(private tableName: string, private dynamoRatchet: DynamoRatchet) {}
 
   public async checkCode(code: string, context: string, deleteOnMatch?: boolean): Promise<boolean> {
     const keys: any = { code: code, context: context };
@@ -21,7 +18,7 @@ export class DynamoExpiringCodeProvider implements ExpiringCodeProvider {
   }
 
   public async storeCode(code: ExpiringCode): Promise<boolean> {
-    const output: PutItemOutput = await this.dynamoRatchet.simplePut(this.tableName, code);
+    const output: PutCommandOutput = await this.dynamoRatchet.simplePut(this.tableName, code);
     return output && output.ConsumedCapacity.CapacityUnits > 0;
   }
 

--- a/src/aws/model/cloud-watch-metrics-minute-level-dynamo-count-request.ts
+++ b/src/aws/model/cloud-watch-metrics-minute-level-dynamo-count-request.ts
@@ -4,11 +4,11 @@
 
 import { KeyValue } from '../../common/key-value';
 import { DynamoRatchet } from '../dynamodb/dynamo-ratchet';
-import { QueryInput, ScanCommandInput } from '@aws-sdk/client-dynamodb';
+import { QueryCommandInput, ScanCommandInput } from '@aws-sdk/lib-dynamodb';
 
 export interface CloudWatchMetricsMinuteLevelDynamoCountRequest {
   dynamoRatchet: DynamoRatchet;
-  query: QueryInput;
+  query: QueryCommandInput;
   scan: ScanCommandInput;
 
   minuteUTC: string; // Format yyyy-MM-dd HH:mm

--- a/src/aws/model/dynamo/doc-put-item-command-input.ts
+++ b/src/aws/model/dynamo/doc-put-item-command-input.ts
@@ -1,11 +1,3 @@
-/*
-This is here because in order to use the DocumentClient in AWS lib V3, you must NOT convert the items
-in the fields below to AttributeValue - but, the only way to do that is to use type ANY!  This interface
-allows you to strongly type everything else while still using the document client.  Makes me wonder if
-anyone at AMZN actually uses their own library...
- */
-import { PutItemCommandInput } from '@aws-sdk/client-dynamodb';
+import { PutCommandInput } from '@aws-sdk/lib-dynamodb';
 
-export interface DocPutItemCommandInput extends PutItemCommandInput {
-  Item: Record<string, any>;
-}
+export type DocPutItemCommandInput = PutCommandInput;

--- a/src/aws/model/dynamo/doc-query-command-input.ts
+++ b/src/aws/model/dynamo/doc-query-command-input.ts
@@ -1,12 +1,3 @@
-/*
-This is here because in order to use the DocumentClient in AWS lib V3, you must NOT convert the items
-in the fields below to AttributeValue - but, the only way to do that is to use type ANY!  This interface
-allows you to strongly type everything else while still using the document client.  Makes me wonder if
-anyone at AMZN actually uses their own library...
- */
-import { QueryCommandInput } from '@aws-sdk/client-dynamodb';
+import { QueryCommandInput } from '@aws-sdk/lib-dynamodb';
 
-export interface DocQueryCommandInput extends QueryCommandInput {
-  ExpressionAttributeValues?: Record<string, any>;
-  ExpressionAttributeNames?: Record<string, any>;
-}
+export type DocQueryCommandInput = QueryCommandInput;

--- a/src/aws/model/dynamo/doc-scan-command-input.ts
+++ b/src/aws/model/dynamo/doc-scan-command-input.ts
@@ -1,12 +1,3 @@
-/*
-This is here because in order to use the DocumentClient in AWS lib V3, you must NOT convert the items
-in the fields below to AttributeValue - but, the only way to do that is to use type ANY!  This interface
-allows you to strongly type everything else while still using the document client.  Makes me wonder if
-anyone at AMZN actually uses their own library...
- */
-import { ScanCommandInput } from '@aws-sdk/client-dynamodb';
+import { ScanCommandInput } from '@aws-sdk/lib-dynamodb';
 
-export interface DocScanCommandInput extends ScanCommandInput {
-  ExpressionAttributeValues?: Record<string, any>;
-  ExpressionAttributeNames?: Record<string, any>;
-}
+export type DocScanCommandInput = ScanCommandInput;

--- a/src/aws/model/dynamo/doc-update-item-command-input.ts
+++ b/src/aws/model/dynamo/doc-update-item-command-input.ts
@@ -1,12 +1,3 @@
-/*
-This is here because in order to use the DocumentClient in AWS lib V3, you must NOT convert the items
-in the fields below to AttributeValue - but, the only way to do that is to use type ANY!  This interface
-allows you to strongly type everything else while still using the document client.  Makes me wonder if
-anyone at AMZN actually uses their own library...
- */
-import { UpdateItemCommandInput } from '@aws-sdk/client-dynamodb';
+import { UpdateCommandInput } from '@aws-sdk/lib-dynamodb';
 
-export interface DocUpdateItemCommandInput extends UpdateItemCommandInput {
-  ExpressionAttributeValues?: Record<string, any>;
-  ExpressionAttributeNames?: Record<string, any>;
-}
+export type DocUpdateItemCommandInput = UpdateCommandInput;

--- a/src/aws/runtime-parameter/dynamo-runtime-parameter-provider.spec.ts
+++ b/src/aws/runtime-parameter/dynamo-runtime-parameter-provider.spec.ts
@@ -2,7 +2,7 @@ import { DynamoRuntimeParameterProvider } from './dynamo-runtime-parameter-provi
 import { DynamoRatchet } from '../dynamodb/dynamo-ratchet';
 import { StoredRuntimeParameter } from './stored-runtime-parameter';
 import { RuntimeParameterRatchet } from './runtime-parameter-ratchet';
-import { PutItemCommandOutput } from '@aws-sdk/client-dynamodb';
+import { PutCommandOutput } from '@aws-sdk/lib-dynamodb';
 import { Logger } from '../../common/logger';
 import { PromiseRatchet } from '../../common/promise-ratchet';
 import { LoggerLevelName } from '../../common/logger-support/logger-level-name';
@@ -22,7 +22,7 @@ describe('#runtimeParameterRatchet', function () {
     Logger.setLevel(LoggerLevelName.silly);
     const tableName: string = 'default-table';
     mockDynamoRatchet.simpleGet.mockResolvedValue(testEntry);
-    mockDynamoRatchet.simplePut.mockResolvedValue({} as PutItemCommandOutput);
+    mockDynamoRatchet.simplePut.mockResolvedValue({} as PutCommandOutput);
     const drpp: DynamoRuntimeParameterProvider = new DynamoRuntimeParameterProvider(mockDynamoRatchet, tableName);
     const rpr: RuntimeParameterRatchet = new RuntimeParameterRatchet(drpp);
 

--- a/src/aws/runtime-parameter/dynamo-runtime-parameter-provider.ts
+++ b/src/aws/runtime-parameter/dynamo-runtime-parameter-provider.ts
@@ -1,4 +1,4 @@
-import { PutItemOutput } from '@aws-sdk/client-dynamodb';
+import { PutCommandOutput } from '@aws-sdk/lib-dynamodb';
 import { RuntimeParameterProvider } from './runtime-parameter-provider';
 import { StoredRuntimeParameter } from './stored-runtime-parameter';
 import { DynamoRatchet } from '../dynamodb/dynamo-ratchet';
@@ -7,10 +7,7 @@ import { Logger } from '../../common/logger';
 import { DocQueryCommandInput } from '../model/dynamo/doc-query-command-input';
 
 export class DynamoRuntimeParameterProvider implements RuntimeParameterProvider {
-  constructor(
-    private dynamo: DynamoRatchet,
-    private tableName: string,
-  ) {
+  constructor(private dynamo: DynamoRatchet, private tableName: string) {
     RequireRatchet.notNullOrUndefined(this.dynamo);
     RequireRatchet.notNullOrUndefined(this.tableName);
   }
@@ -40,7 +37,7 @@ export class DynamoRuntimeParameterProvider implements RuntimeParameterProvider 
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public async writeParameter(toStore: StoredRuntimeParameter): Promise<boolean> {
-    const rval: PutItemOutput = await this.dynamo.simplePut(this.tableName, toStore);
+    const rval: PutCommandOutput = await this.dynamo.simplePut(this.tableName, toStore);
     return !!rval;
   }
 }

--- a/src/aws/s3/s3-cache-ratchet.ts
+++ b/src/aws/s3/s3-cache-ratchet.ts
@@ -33,10 +33,7 @@ import { S3CacheRatchetLike } from './s3-cache-ratchet-like';
 import { ExpandedFileChildren } from './expanded-file-children';
 
 export class S3CacheRatchet implements S3CacheRatchetLike {
-  constructor(
-    private s3: S3Client,
-    private defaultBucket: string = null,
-  ) {
+  constructor(private s3: S3Client, private defaultBucket: string = null) {
     RequireRatchet.notNullOrUndefined(this.s3, 's3');
   }
 
@@ -151,7 +148,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
     key: string,
     dataObject: any, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types
     template?: PutObjectCommandInput,
-    bucket?: string,
+    bucket?: string
   ): Promise<CompleteMultipartUploadCommandOutput> {
     const json = JSON.stringify(dataObject);
     return this.writeStringToCacheFile(key, json, template, bucket);
@@ -162,7 +159,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
     key: string,
     dataString: string,
     template?: PutObjectCommandInput,
-    bucket?: string,
+    bucket?: string
   ): Promise<CompleteMultipartUploadCommandOutput> {
     const stream: ReadableStream = WebStreamRatchet.stringToWebReadableStream(dataString);
     return this.writeStreamToCacheFile(key, stream, template, bucket);
@@ -172,7 +169,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
     key: string,
     data: ReadableStream | Readable,
     template?: PutObjectCommandInput,
-    bucket?: string,
+    bucket?: string
   ): Promise<CompleteMultipartUploadCommandOutput> {
     const params: PutObjectCommandInput = Object.assign({}, template || {}, {
       Bucket: this.bucketVal(bucket),
@@ -201,7 +198,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
     srcPrefix: string,
     targetPrefix: string,
     targetRatchet: S3CacheRatchetLike = this,
-    recurseSubFolders: boolean = false,
+    recurseSubFolders: boolean = false
   ): Promise<string[]> {
     RequireRatchet.notNullOrUndefined(srcPrefix, 'srcPrefix');
     RequireRatchet.notNullOrUndefined(targetPrefix, 'targetPrefix');
@@ -222,7 +219,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
             srcPrefix + sourceFile,
             targetPrefix + sourceFile,
             targetRatchet,
-            recurseSubFolders,
+            recurseSubFolders
           );
           Logger.info('Got %d back from %s', subs.length, sourceFile);
           rval = rval.concat(subs);
@@ -247,7 +244,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
               targetPrefix + sourceFile,
               srcStream,
               srcMeta as unknown as PutObjectCommandInput, // Carry forward any metadata
-              undefined,
+              undefined
             );
             Logger.silly('Write result : %j', written);
             rval.push(sourceFile);
@@ -270,7 +267,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
         new HeadObjectCommand({
           Bucket: this.bucketVal(bucket),
           Key: key,
-        }),
+        })
       );
     } catch (err) {
       if (err && err['statusCode'] == 404) {
@@ -307,7 +304,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
     srcKey: string,
     dstKey: string,
     srcBucket: string = null,
-    dstBucket: string = null,
+    dstBucket: string = null
   ): Promise<CopyObjectCommandOutput> {
     const params: CopyObjectCommandInput = {
       CopySource: '/' + this.bucketVal(srcBucket) + '/' + srcKey,
@@ -343,7 +340,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
     prefix: string,
     expandFiles = false,
     bucket: string = null,
-    maxToReturn: number = null,
+    maxToReturn: number = null
   ): Promise<string[]> {
     const returnValue: any[] = [];
 
@@ -384,7 +381,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
                 returnValue.push(cp['Key'].substring(prefixLength));
               }
             }
-          }),
+          })
         );
       }
       params.Marker = response.NextMarker;

--- a/src/node-only/aws/dynamo-exporter.ts
+++ b/src/node-only/aws/dynamo-exporter.ts
@@ -1,6 +1,6 @@
 import fs, { WriteStream } from 'fs';
 import readline from 'readline';
-import { QueryCommandInput, ScanCommandInput } from '@aws-sdk/client-dynamodb';
+import { QueryCommandInput, ScanCommandInput } from '@aws-sdk/lib-dynamodb';
 import { DynamoRatchet } from '../../aws/dynamodb/dynamo-ratchet';
 import { RequireRatchet } from '../../common/require-ratchet';
 import { StringRatchet } from '../../common/string-ratchet';
@@ -80,7 +80,7 @@ export class DynamoExporter {
     RequireRatchet.notNullOrUndefined(target, 'target');
 
     const rval: number = await dynamo.fullyExecuteProcessOverScan(scan, async (row) =>
-      DynamoExporter.writeItemToJsonLStream(row, target, false),
+      DynamoExporter.writeItemToJsonLStream(row, target, false)
     );
     return rval;
   }
@@ -91,7 +91,7 @@ export class DynamoExporter {
     RequireRatchet.notNullOrUndefined(target, 'target');
 
     const rval: number = await dynamo.fullyExecuteProcessOverQuery(qry, async (row) =>
-      DynamoExporter.writeItemToJsonLStream(row, target, false),
+      DynamoExporter.writeItemToJsonLStream(row, target, false)
     );
     return rval;
   }


### PR DESCRIPTION
The fundamental trick is:

When dealing with items (as opposed to tables), always import the commands, inputs, and outputs from `@aws-sdk/lib-dynamodb` and **not** `@aws-sdk/client-dynamodb`. That will ensure you get the types that expect the library to do the attribute marshaling for you.

The types in the base client (`@aws-sdk/client-dynamodb`) expect you to handle the marshaling on your own, which then requires a lot of `convertToAttr` calls (or similar).

It just doesn't help that the commands, inputs, and outputs sometimes have similar (and sometimes duplicate) names between the two packages, while the types are often so similar to each other that Typescript will sometimes accept one as the other because they're sufficiently similar.