### PR TITLE
Fix S3 cache ratchet detection of 404 not found

### DIFF
--- a/src/aws/s3/s3-cache-ratchet.ts
+++ b/src/aws/s3/s3-cache-ratchet.ts
@@ -17,6 +17,7 @@ import {
   ListObjectsV2CommandInput,
   ListObjectsV2CommandOutput,
   NoSuchKey,
+  NotFound,
   PutObjectCommandInput,
   PutObjectCommandOutput,
   S3Client,
@@ -133,7 +134,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
     try {
       rval = await this.s3.send(new DeleteObjectCommand(params));
     } catch (err) {
-      if (err && err['statusCode'] == 404) {
+      if (err && err instanceof NotFound) {
         Logger.info('Swallowing 404 deleting missing object %s %s', bucket, key);
         rval = null;
       } else {
@@ -267,10 +268,10 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
         new HeadObjectCommand({
           Bucket: this.bucketVal(bucket),
           Key: key,
-        })
+        }),
       );
     } catch (err) {
-      if (err && err['statusCode'] == 404) {
+      if (err && err instanceof NotFound) {
         Logger.info('Cache file %s %s not found returning null', this.bucketVal(bucket), key);
         rval = null;
       } else {
@@ -291,7 +292,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
         return null;
       }
     } catch (err) {
-      if (err && err['statusCode'] == 404) {
+      if (err && err instanceof NotFound) {
         Logger.warn('Cache file %s %s not found returning null', this.bucketVal(bucket), key);
         return null;
       } else {


### PR DESCRIPTION
S3CacheRatchet is not properly detecting when it gets a "Not Found" response and throwing it as if it's an unexpected error. This fixes that.