### PR TITLE
Fix DynamoRatchet log message formatting, tone down S3 upload progress log

### DIFF
--- a/src/aws/daemon/daemon-util.ts
+++ b/src/aws/daemon/daemon-util.ts
@@ -129,7 +129,7 @@ export class DaemonUtil {
     });
 
     upload.on('httpUploadProgress', (progress) => {
-      Logger.info('Uploading : %s', progress);
+      Logger.debug('Uploading : %s', progress);
     });
     const written: CompleteMultipartUploadCommandOutput = await upload.done();
 

--- a/src/aws/dynamodb/dynamo-ratchet.ts
+++ b/src/aws/dynamodb/dynamo-ratchet.ts
@@ -387,7 +387,7 @@ export class DynamoRatchet implements DynamoRatchetLike {
           !!batchResults.UnprocessedItems[tableName] &&
           batchResults.UnprocessedItems[tableName].length > 0
         ) {
-          Logger.error('After 6 tries there were still %d unprocessed items');
+          Logger.error('After 6 tries there were still %d unprocessed items', batchResults.UnprocessedItems[tableName].length);
           rval += curBatch.length - batchResults.UnprocessedItems[tableName].length;
           Logger.warn('FIX Unprocessed : %j', batchResults.UnprocessedItems);
         } else {
@@ -531,7 +531,7 @@ export class DynamoRatchet implements DynamoRatchetLike {
           !!batchResults.UnprocessedItems[tableName] &&
           batchResults.UnprocessedItems[tableName].length > 0
         ) {
-          Logger.error('After 6 tries there were still %d unprocessed items');
+          Logger.error('After 6 tries there were still %d unprocessed items', batchResults.UnprocessedItems[tableName].length);
           rval += curBatch.length - batchResults.UnprocessedItems[tableName].length;
           Logger.warn('FIX Unprocessed : %j', batchResults.UnprocessedItems);
         } else {

--- a/src/aws/s3/s3-cache-ratchet.ts
+++ b/src/aws/s3/s3-cache-ratchet.ts
@@ -188,7 +188,7 @@ export class S3CacheRatchet implements S3CacheRatchetLike {
     });
 
     upload.on('httpUploadProgress', (progress) => {
-      Logger.info('Uploading : %s', progress);
+      Logger.debug('Uploading : %s', progress);
     });
     const result: CompleteMultipartUploadCommandOutput = await upload.done();
 

--- a/src/aws/s3/s3-location-sync-ratchet.ts
+++ b/src/aws/s3/s3-location-sync-ratchet.ts
@@ -98,7 +98,7 @@ export class S3LocationSyncRatchet {
           });
 
           upload.on('httpUploadProgress', (progress) => {
-            Logger.info('Uploading : %s', progress);
+            Logger.debug('Uploading : %s', progress);
           });
           await upload.done();
         }

--- a/src/site-uploader/site-uploader.ts
+++ b/src/site-uploader/site-uploader.ts
@@ -117,7 +117,7 @@ export class SiteUploader {
           });
 
           upload.on('httpUploadProgress', (progress) => {
-            Logger.info('Uploading : %s', progress);
+            Logger.debug('Uploading : %s', progress);
           });
           upload
             .done()


### PR DESCRIPTION
The `DynamoRatchet` log message isn't including a value to match its `%d` parameter.

This also reduces the log level for S3 uploads from `info` to `debug`. A pretty significant chunk of our log messages in Neon are from these, and the vast majority of the time, the "progress" is just that there's one part and it's complete.