### PR TITLE
Fix AWS large payload manager to use correct modify method name

### DIFF
--- a/modules/epsilon-common/src/background/manager/aws-large-payload-s3-sqs-sns-background-manager.ts
+++ b/modules/epsilon-common/src/background/manager/aws-large-payload-s3-sqs-sns-background-manager.ts
@@ -74,7 +74,7 @@ export class AwsLargePayloadS3SqsSnsBackgroundManager extends AwsSqsSnsBackgroun
     return s3FilePath;
   }
 
-  public async modify<T>(entry: InternalBackgroundEntry<T>): Promise<InternalBackgroundEntry<T>> {
+  public async modifyPayloadPreProcess<T>(entry: InternalBackgroundEntry<T>): Promise<InternalBackgroundEntry<T>> {
     if (entry?.meta?.[AwsLargePayloadS3SqsSnsBackgroundManager.LARGE_MESSAGE_S3_PATH_META_KEY]) {
       Logger.silly('Restoring large data from %s', entry.meta[AwsLargePayloadS3SqsSnsBackgroundManager.LARGE_MESSAGE_S3_PATH_META_KEY]);
       const parsed: T = await this._s3.fetchCacheFileAsObject<T>(


### PR DESCRIPTION
The `AwsLargePayloadS3SqsSnsBackgroundManager` class seems to define a method called `modify`, but in order for it to get called, it needs to be named `modifyPayloadPreProcess`.

The code that would actually call it is here:
https://github.com/bitblit/Ratchet/blob/906857638136f0fec6a69fd47e37c6769a22b1fc/modules/epsilon-common/src/background/background-handler.ts#L274

This PR renames the method to the expected name.